### PR TITLE
Added checks for bluemix services SQLDB and BLUAcceleration

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,6 +24,13 @@ ZS_PATCHES="ZCLOUD-147 ZSRV-11471 ZSRV-11843 ZCLOUD-131 ZCLOUD-168"
 # include .files when moving things around
 shopt -s dotglob
 
+# If ZEND_DB2_DRIVER is not set to 0, then look for services which use db2 driver
+if [[ $ZEND_DB2_DRIVER != 0 ]]; then
+   if [[ "${VCAP_SERVICES}" == *BLUAcceleration* ]] || [[ "${VCAP_SERVICES}" == *SQLDB* ]]; then
+      ZEND_DB2_DRIVER=1
+   fi 
+fi
+
 if [[ $ZEND_DB2_DRIVER == 1 ]]; then
     ZS_PATCHES="$ZS_PATCHES ZCLOUD-181"
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,6 +13,13 @@ export ZEND_GID=`id -g`
 export ZS_EDITION=TRIAL
 ZS_MANAGE=/app/zend-server-6-php-5.4/bin/zs-manage
 
+# If ZEND_DB2_DRIVER is not set to 0, then look for services which use db2 driver
+if [[ $ZEND_DB2_DRIVER != 0 ]]; then
+   if [[ "${VCAP_SERVICES}" == *BLUAcceleration* ]] || [[ "${VCAP_SERVICES}" == *SQLDB* ]]; then
+      ZEND_DB2_DRIVER=1
+   fi 
+fi
+
 # Set env. variables for DB2 if needed
 if [[ $ZEND_DB2_DRIVER == 1 ]]; then
     export LD_LIBRARY_PATH=/app/clidriver/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
If ZEND_DB2_DRIVER is not explicitly set to 0 , then look in VCAP_SERVICES for bluemix services which need DB2 Driver and set ZEND_DB2_DRIVER to 1.  The services are SQLDB and BLUAcceleration. 
